### PR TITLE
Test calculate revision date

### DIFF
--- a/common.mjs
+++ b/common.mjs
@@ -1,3 +1,28 @@
 export function getUserIds() {
   return ["1", "2", "3", "4", "5"];
 }
+
+export function calculateRevisionDate(selectedDate) {
+  const revisionDateArray = [];
+  //one week later
+  const oneWeek = new Date(selectedDate);
+  oneWeek.setDate(selectedDate.getDate() + 7);
+  revisionDateArray.push(oneWeek.toLocaleDateString());
+  //One Month Later
+  const oneMonth = new Date(selectedDate);
+  oneMonth.setMonth(selectedDate.getMonth() + 1);
+  revisionDateArray.push(oneMonth.toLocaleDateString());
+  //Three Month Later
+  const threeMonth = new Date(selectedDate);
+  threeMonth.setMonth(selectedDate.getMonth() + 3);
+  revisionDateArray.push(threeMonth.toLocaleDateString());
+  //Six Month Later
+  const sixMonth = new Date(selectedDate);
+  sixMonth.setMonth(selectedDate.getMonth() + 6);
+  revisionDateArray.push(sixMonth.toLocaleDateString());
+  //One Year
+  const oneYear = new Date(selectedDate);
+  oneYear.setFullYear(selectedDate.getFullYear() + 1);
+  revisionDateArray.push(oneYear.toLocaleDateString());
+  return revisionDateArray;
+}

--- a/common.mjs
+++ b/common.mjs
@@ -7,22 +7,27 @@ export function calculateRevisionDate(selectedDate) {
   //one week later
   const oneWeek = new Date(selectedDate);
   oneWeek.setDate(selectedDate.getDate() + 7);
-  revisionDateArray.push(oneWeek.toLocaleDateString());
+  revisionDateArray.push(oneWeek.toISOString().split("T")[0]);
+  //revisionDateArray.push(oneWeek.toLocaleDateString());
   //One Month Later
   const oneMonth = new Date(selectedDate);
   oneMonth.setMonth(selectedDate.getMonth() + 1);
-  revisionDateArray.push(oneMonth.toLocaleDateString());
+  revisionDateArray.push(oneMonth.toISOString().split("T")[0]);
+  //revisionDateArray.push(oneMonth.toLocaleDateString());
   //Three Month Later
   const threeMonth = new Date(selectedDate);
   threeMonth.setMonth(selectedDate.getMonth() + 3);
-  revisionDateArray.push(threeMonth.toLocaleDateString());
+  revisionDateArray.push(threeMonth.toISOString().split("T")[0]);
+  //revisionDateArray.push(threeMonth.toLocaleDateString());
   //Six Month Later
   const sixMonth = new Date(selectedDate);
   sixMonth.setMonth(selectedDate.getMonth() + 6);
-  revisionDateArray.push(sixMonth.toLocaleDateString());
+  revisionDateArray.push(sixMonth.toISOString().split("T")[0]);
+  //revisionDateArray.push(sixMonth.toLocaleDateString());
   //One Year
   const oneYear = new Date(selectedDate);
   oneYear.setFullYear(selectedDate.getFullYear() + 1);
-  revisionDateArray.push(oneYear.toLocaleDateString());
+  revisionDateArray.push(oneYear.toISOString().split("T")[0]);
+  //revisionDateArray.push(oneYear.toLocaleDateString());
   return revisionDateArray;
 }

--- a/common.test.mjs
+++ b/common.test.mjs
@@ -1,4 +1,4 @@
-import { getUserIDs } from "./common.mjs";
+import { getUserIds } from "./common.mjs";
 import assert from "node:assert";
 import test from "node:test";
 

--- a/common.test.mjs
+++ b/common.test.mjs
@@ -10,11 +10,11 @@ test("User count is correct", () => {
 test("calculateRevisionDate returns correct future dates", () => {
   const selectedDate = new Date("2026-07-01");
   const expectedDates = [
-    new Date("2026-07-08").toLocaleDateString(),
-    new Date("2026-08-01").toLocaleDateString(),
-    new Date("2026-10-01").toLocaleDateString(),
-    new Date("2027-01-01").toLocaleDateString(),
-    new Date("2027-07-01").toLocaleDateString(),
+    new Date("2026-07-08").toISOString().split("T")[0],
+    new Date("2026-08-01").toISOString().split("T")[0],
+    new Date("2026-10-01").toISOString().split("T")[0],
+    new Date("2027-01-01").toISOString().split("T")[0],
+    new Date("2027-07-01").toISOString().split("T")[0],
   ];
   const revisionDates = calculateRevisionDate(selectedDate);
   assert.deepStrictEqual(revisionDates,expectedDates);
@@ -23,11 +23,11 @@ test("calculateRevisionDate returns correct future dates", () => {
 test("calculateRevisionDate returns correct future dates", () => {
   const selectedDate = new Date("2026-01-31");
   const expectedDates = [
-    new Date("2/7/2026").toLocaleDateString(),
-    new Date("3/3/2026").toLocaleDateString(),
-    new Date("5/1/2026").toLocaleDateString(),
-    new Date("7/31/2026").toLocaleDateString(),
-    new Date("1/31/2027").toLocaleDateString(),
+    new Date("2/7/2026").toISOString().split("T")[0],
+    new Date("3/3/2026").toISOString().split("T")[0],
+    new Date("5/1/2026").toISOString().split("T")[0],
+    new Date("7/31/2026").toISOString().split("T")[0],
+    new Date("1/31/2027").toISOString().split("T")[0],
   ];
   const revisionDates = calculateRevisionDate(selectedDate);
   assert.deepStrictEqual(revisionDates, expectedDates);
@@ -36,11 +36,11 @@ test("calculateRevisionDate returns correct future dates", () => {
 test("calculateRevisionDate returns correct future dates", () => {
   const selectedDate = new Date("2026-12-15");
   const expectedDates = [
-    new Date("12/22/2026").toLocaleDateString(),
-    new Date("1/15/2027").toLocaleDateString(),
-    new Date("3/15/2027").toLocaleDateString(),
-    new Date("6/15/2027").toLocaleDateString(),
-    new Date("12/15/2027").toLocaleDateString(),
+    new Date("12/22/2026").toISOString().split("T")[0],
+    new Date("1/15/2027").toISOString().split("T")[0],
+    new Date("3/15/2027").toISOString().split("T")[0],
+    new Date("6/15/2027").toISOString().split("T")[0],
+    new Date("12/15/2027").toISOString().split("T")[0],
   ];
   const revisionDates = calculateRevisionDate(selectedDate);
   assert.deepStrictEqual(revisionDates, expectedDates);
@@ -49,11 +49,11 @@ test("calculateRevisionDate returns correct future dates", () => {
 test("calculateRevisionDate returns correct future dates", () => {
   const selectedDate = new Date("2024-02-28");
   const expectedDates = [
-    new Date("3/6/2024").toLocaleDateString(),
-    new Date("3/28/2024").toLocaleDateString(),
-    new Date("5/28/2024").toLocaleDateString(),
-    new Date("8/28/2024").toLocaleDateString(),
-    new Date("2/28/2025").toLocaleDateString(),
+    new Date("3/6/2024").toISOString().split("T")[0],
+    new Date("3/28/2024").toISOString().split("T")[0],
+    new Date("5/28/2024").toISOString().split("T")[0],
+    new Date("8/28/2024").toISOString().split("T")[0],
+    new Date("2/28/2025").toISOString().split("T")[0],
   ];
   const revisionDates = calculateRevisionDate(selectedDate);
   assert.deepStrictEqual(revisionDates, expectedDates);

--- a/common.test.mjs
+++ b/common.test.mjs
@@ -1,7 +1,21 @@
 import { getUserIds } from "./common.mjs";
+import { calculateRevisionDate } from "./common.mjs";
 import assert from "node:assert";
 import test from "node:test";
 
 test("User count is correct", () => {
   assert.equal(getUserIds().length, 5);
+});
+
+test("calculateRevisionDate returns correct future dates", () => {
+  const selectedDate = new Date("2026-07-01");
+  const expectedDates = [
+    new Date("2026-07-08").toLocaleDateString(),
+    new Date("2026-08-01").toLocaleDateString(),
+    new Date("2026-10-01").toLocaleDateString(),
+    new Date("2027-01-01").toLocaleDateString(),
+    new Date("2027-07-01").toLocaleDateString(),
+  ];
+  const revisionDates = calculateRevisionDate(selectedDate);
+  assert.equal(revisionDates,expectedDates);
 });

--- a/common.test.mjs
+++ b/common.test.mjs
@@ -19,3 +19,42 @@ test("calculateRevisionDate returns correct future dates", () => {
   const revisionDates = calculateRevisionDate(selectedDate);
   assert.deepStrictEqual(revisionDates,expectedDates);
 });
+//end of month
+test("calculateRevisionDate returns correct future dates", () => {
+  const selectedDate = new Date("2026-01-31");
+  const expectedDates = [
+    new Date("2/7/2026").toLocaleDateString(),
+    new Date("3/3/2026").toLocaleDateString(),
+    new Date("5/1/2026").toLocaleDateString(),
+    new Date("7/31/2026").toLocaleDateString(),
+    new Date("1/31/2027").toLocaleDateString(),
+  ];
+  const revisionDates = calculateRevisionDate(selectedDate);
+  assert.deepStrictEqual(revisionDates, expectedDates);
+});
+//end of year
+test("calculateRevisionDate returns correct future dates", () => {
+  const selectedDate = new Date("2026-12-15");
+  const expectedDates = [
+    new Date("12/22/2026").toLocaleDateString(),
+    new Date("1/15/2027").toLocaleDateString(),
+    new Date("3/15/2027").toLocaleDateString(),
+    new Date("6/15/2027").toLocaleDateString(),
+    new Date("12/15/2027").toLocaleDateString(),
+  ];
+  const revisionDates = calculateRevisionDate(selectedDate);
+  assert.deepStrictEqual(revisionDates, expectedDates);
+});
+//Leap year
+test("calculateRevisionDate returns correct future dates", () => {
+  const selectedDate = new Date("2024-02-28");
+  const expectedDates = [
+    new Date("3/6/2024").toLocaleDateString(),
+    new Date("3/28/2024").toLocaleDateString(),
+    new Date("5/28/2024").toLocaleDateString(),
+    new Date("8/28/2024").toLocaleDateString(),
+    new Date("2/28/2025").toLocaleDateString(),
+  ];
+  const revisionDates = calculateRevisionDate(selectedDate);
+  assert.deepStrictEqual(revisionDates, expectedDates);
+});

--- a/common.test.mjs
+++ b/common.test.mjs
@@ -17,5 +17,5 @@ test("calculateRevisionDate returns correct future dates", () => {
     new Date("2027-07-01").toLocaleDateString(),
   ];
   const revisionDates = calculateRevisionDate(selectedDate);
-  assert.equal(revisionDates,expectedDates);
+  assert.deepStrictEqual(revisionDates,expectedDates);
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "At Code Your Future, we like to use a learning technique called spaced repetition. The technique involves reviewing a topic over increasing time gaps (e.g. after one week, one month, three months, six months, one year).",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/script.mjs
+++ b/script.mjs
@@ -9,6 +9,8 @@ import { getUserIds } from "./common.mjs";
 import { getData } from "./storage.mjs";
 import { addData } from "./storage.mjs";
 import { clearData } from "./storage.mjs";
+import { calculateRevisionDate } from "./common.mjs";
+
 
 
 window.onload = function () {
@@ -90,31 +92,7 @@ window.onload = function () {
     agendaContent.appendChild(agendaUl);
   }
 
-  function calculateRevisionDate(selectedDate) {
-    const revisionDateArray = [];
-    //one week later
-    const oneWeek = new Date(selectedDate);
-    oneWeek.setDate(selectedDate.getDate() + 7);
-    revisionDateArray.push(oneWeek.toLocaleDateString());
-    //One Month Later
-    const oneMonth = new Date(selectedDate);
-    oneMonth.setMonth(selectedDate.getMonth() + 1);
-    revisionDateArray.push(oneMonth.toLocaleDateString());
-    //Three Month Later
-    const threeMonth = new Date(selectedDate);
-    threeMonth.setMonth(selectedDate.getMonth() + 3);
-    revisionDateArray.push(threeMonth.toLocaleDateString());
-    //Six Month Later
-    const sixMonth = new Date(selectedDate);
-    sixMonth.setMonth(selectedDate.getMonth() + 6);
-    revisionDateArray.push(sixMonth.toLocaleDateString());
-    //One Year
-    const oneYear = new Date(selectedDate);
-    oneYear.setFullYear(selectedDate.getFullYear() + 1);
-    revisionDateArray.push(oneYear.toLocaleDateString());
-    return revisionDateArray;
-  }
-
+  
   //create form
   const form = document.createElement("form");
   document.body.append(form);


### PR DESCRIPTION
I moved the calculateRevisionDate function to the common module so that it can be properly imported into script.mjs and tested using npm test. 
I also placed the new test cases in the pre-existing test module. Additionally, I fixed a typo in the getUserIds name  that was causing an error in test process.